### PR TITLE
Fix issue DistinctInPlaceF crashing

### DIFF
--- a/LinqFaster/Distinct.cs
+++ b/LinqFaster/Distinct.cs
@@ -24,6 +24,11 @@ namespace JM.LinqFaster
                 throw Error.ArgumentNull("source");
             }
 
+            if (source.Count == 0)
+            {
+                return;
+            }
+
             if (comparer == null)
             {
                 comparer = Comparer<TSource>.Default;

--- a/Tests/DistinctTests.cs
+++ b/Tests/DistinctTests.cs
@@ -1,11 +1,32 @@
 ﻿using NUnit.Framework;
+using JM.LinqFaster;
+using System.Linq;
+using static Tests.Test;
+using System.Collections.Generic;
 
 namespace Tests
 {
     [TestFixture]
     class DistinctTests {
 
-       
+        [Test]
+        public void DistinctInPlaceEmptyList()
+        {
+            var emptyList = new List<int>();
 
+            emptyList.DistinctInPlaceF();
+        }
+
+        [Test]
+        public void DistinctInPlaceIntegerList()
+        {
+            var list = new List<int>() { 1, 2, 2, 3, 3, 3 };
+            var a = new List<int>(list);
+            var b = list.Distinct().ToList();
+
+            a.DistinctInPlaceF();
+
+            Assert.That(a, Is.EqualTo(b));
+        }
     }
 }


### PR DESCRIPTION
Currently DistinctInPlaceF is crashing when called on an empty collection. 
The error thrown is System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection.
Added test case and normal testcase which isn't present currently.